### PR TITLE
Use relative path for CI github badge, otherwise it is hardcoded to the template repo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CI](https://github.com/tomogwen/pytemplate/actions/workflows/ci.yml/badge.svg)](https://github.com/tomogwen/pytemplate/actions/workflows/ci.yml)
+[![CI](actions/workflows/ci.yml/badge.svg)](actions/workflows/ci.yml)
 
 # 📝 Python Project Template
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CI](actions/workflows/ci.yml/badge.svg)](actions/workflows/ci.yml)
+[![CI](../../actions/workflows/ci.yml/badge.svg)](../../actions/workflows/ci.yml)
 
 # 📝 Python Project Template
 


### PR DESCRIPTION
Doesn't show properly in the template itself for some reason but works when forked